### PR TITLE
Replace boolean type with bool in examples

### DIFF
--- a/examples/Ethernet/RegisteringServices/RegisteringServices.ino
+++ b/examples/Ethernet/RegisteringServices/RegisteringServices.ino
@@ -85,7 +85,7 @@ void loop()
   EthernetClient client = server.available();
   if (client) {
     // an http request ends with a blank line
-    boolean current_line_is_blank = true;
+    bool current_line_is_blank = true;
     while (client.connected()) {
       if (client.available()) {
         char c = client.read();

--- a/examples/Ethernet/RegisteringServicesWithTxtRecord/RegisteringServicesWithTxtRecord.ino
+++ b/examples/Ethernet/RegisteringServicesWithTxtRecord/RegisteringServicesWithTxtRecord.ino
@@ -99,7 +99,7 @@ void loop()
   char isPage2 = 0;
   if (client) {
     // an http request ends with a blank line
-    boolean current_line_is_blank = true;
+    bool current_line_is_blank = true;
     while (client.connected()) {
       if (client.available()) {
         char c = client.read();

--- a/examples/WiFi/WiFiRegisteringServices/WiFiRegisteringServices.ino
+++ b/examples/WiFi/WiFiRegisteringServices/WiFiRegisteringServices.ino
@@ -102,7 +102,7 @@ void loop()
   WiFiClient client = server.available();
   if (client) {
     // an http request ends with a blank line
-    boolean current_line_is_blank = true;
+    bool current_line_is_blank = true;
     while (client.connected()) {
       if (client.available()) {
         char c = client.read();

--- a/examples/WiFi/WiFiRegisteringServicesWithTxtRecord/WiFiRegisteringServicesWithTxtRecord.ino
+++ b/examples/WiFi/WiFiRegisteringServicesWithTxtRecord/WiFiRegisteringServicesWithTxtRecord.ino
@@ -118,7 +118,7 @@ void loop()
   char isPage2 = 0;
   if (client) {
     // an http request ends with a blank line
-    boolean current_line_is_blank = true;
+    bool current_line_is_blank = true;
     while (client.connected()) {
       if (client.available()) {
         char c = client.read();


### PR DESCRIPTION
Replace boolean type with bool in examples

This is part of a move to encourage use of the standard bool type over Arduino's non-standard boolean type alias.

As approved by cmaglie: https://github.com/arduino/Arduino/issues/6657#issuecomment-355597633