### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,24 +6,24 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-ArduinoMDNS			KEYWORD1
-MDNS			KEYWORD1
+ArduinoMDNS	KEYWORD1
+MDNS	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-begin					KEYWORD2
-setName			KEYWORD2
-addServiceRecord		KEYWORD2
-run						KEYWORD2
-removeServiceRecord 	KEYWORD2
-removeAllServiceRecords KEYWORD2
-setNameResolvedCallback KEYWORD2
-resolveName				KEYWORD2
-cancelResolveName		KEYWORD2
-isResolvingName			KEYWORD2
-setServiceFoundCallback KEYWORD2
-startDiscoveringService KEYWORD2
+begin	KEYWORD2
+setName	KEYWORD2
+addServiceRecord	KEYWORD2
+run	KEYWORD2
+removeServiceRecord	KEYWORD2
+removeAllServiceRecords	KEYWORD2
+setNameResolvedCallback	KEYWORD2
+resolveName	KEYWORD2
+cancelResolveName	KEYWORD2
+isResolvingName	KEYWORD2
+setServiceFoundCallback	KEYWORD2
+startDiscoveringService	KEYWORD2
 stopDiscoveringService	KEYWORD2
 isDiscoveringService	KEYWORD2
 #######################################


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords