### PR TITLE
Use GitHub Actions for continuous integration

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,7 @@
+# See: https://github.com/codespell-project/codespell#using-a-config-file
+[codespell]
+# In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
+ignore-words-list = ,
+check-filenames =
+check-hidden =
+skip = ./.git

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# See: https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#about-the-dependabotyml-file
+version: 2
+
+updates:
+  # Configure check for outdated GitHub Actions actions in workflows.
+  # See: https://docs.github.com/en/github/administering-a-repository/keeping-your-actions-up-to-date-with-dependabot
+  - package-ecosystem: github-actions
+    directory: / # Check the repository's workflows under /.github/workflows/
+    schedule:
+      interval: daily

--- a/.github/workflows/check-arduino.yml
+++ b/.github/workflows/check-arduino.yml
@@ -1,0 +1,29 @@
+name: Check Arduino
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+  pull_request:
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage caused by new rules added to Arduino Lint.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Arduino Lint
+        uses: arduino/arduino-lint-action@v1
+        with:
+          compliance: specification
+          # Change this to "update" once the library is added to the index.
+          library-manager: submit
+          # Always use this setting for official repositories. Remove for 3rd party projects.
+          official: true
+          project-type: library

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -23,6 +23,9 @@ jobs:
     name: ${{ matrix.board.fqbn }}
     runs-on: ubuntu-latest
 
+    env:
+      SKETCHES_REPORTS_PATH: sketches-reports
+
     strategy:
       fail-fast: false
 
@@ -116,3 +119,12 @@ jobs:
             ${{ matrix.libraries }}
           sketch-paths: |
             ${{ matrix.sketch-paths }}
+          enable-deltas-report: true
+          sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}
+
+      - name: Save sketches report as workflow artifact
+        uses: actions/upload-artifact@v2
+        with:
+          if-no-files-found: error
+          path: ${{ env.SKETCHES_REPORTS_PATH }}
+          name: ${{ env.SKETCHES_REPORTS_PATH }}

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -1,0 +1,118 @@
+name: Compile Examples
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/compile-examples.yml"
+      - "examples/**"
+      - "src/**"
+  pull_request:
+    paths:
+      - ".github/workflows/compile-examples.yml"
+      - "examples/**"
+      - "src/**"
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage caused by changes to external resources (libraries, platforms).
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  build:
+    name: ${{ matrix.board.fqbn }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        board:
+          - fqbn: arduino:avr:nano
+            platforms: |
+              - name: arduino:avr
+            type: ethernet
+          - fqbn: arduino:avr:mega
+            platforms: |
+              - name: arduino:avr
+            type: ethernet
+          - fqbn: arduino:avr:leonardo
+            platforms: |
+              - name: arduino:avr
+            type: ethernet
+          - fqbn: arduino:megaavr:uno2018
+            platforms: |
+              - name: arduino:megaavr
+            type: ethernet
+          - fqbn: arduino:megaavr:nona4809
+            platforms: |
+              - name: arduino:megaavr
+            type: ethernet
+          - fqbn: arduino:sam:arduino_due_x_dbg
+            platforms: |
+              - name: arduino:sam
+            type: ethernet
+          - fqbn: arduino:samd:arduino_zero_edbg
+            platforms: |
+              - name: arduino:samd
+            type: ethernet
+          - fqbn: arduino:samd:mkrzero
+            platforms: |
+              - name: arduino:samd
+            type: ethernet
+          - fqbn: arduino:samd:nano_33_iot
+            platforms: |
+              - name: arduino:samd
+            type: ethernet
+          - fqbn: arduino:mbed_portenta:envie_m4
+            platforms: |
+              - name: arduino:mbed_portenta
+            type: ethernet
+          - fqbn: arduino:mbed_portenta:envie_m7
+            platforms: |
+              - name: arduino:mbed_portenta
+            type: ethernet
+          - fqbn: arduino:mbed_nano:nano33ble
+            platforms: |
+              - name: arduino:mbed_nano
+            type: ethernet
+          - fqbn: arduino:mbed_nano:nanorp2040connect
+            platforms: |
+              - name: arduino:mbed_nano
+            type: ethernet
+          - fqbn: arduino:samd:mkr1000
+            platforms: |
+              - name: arduino:samd
+            type: wifi101
+
+        # make board type-specific customizations to the matrix jobs
+        include:
+          - board:
+              type: ethernet
+            libraries: |
+              - name: Ethernet
+            sketch-paths: |
+              - examples/Ethernet
+          - board:
+              type: wifi101
+            libraries: |
+              - name: WiFi101
+            sketch-paths: |
+              - examples/WiFi
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Compile examples
+        uses: arduino/compile-sketches@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fqbn: ${{ matrix.board.fqbn }}
+          platforms: ${{ matrix.board.platforms }}
+          libraries: |
+            # Install the library from the local path.
+            - source-path: ./
+            ${{ matrix.libraries }}
+          sketch-paths: |
+            ${{ matrix.sketch-paths }}

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -1,0 +1,24 @@
+name: Report Size Deltas
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/report-size-deltas.yml"
+  schedule:
+    # Run at the minimum interval allowed by GitHub Actions.
+    # Note: GitHub Actions periodically has outages which result in workflow failures.
+    # In this event, the workflows will start passing again once the service recovers.
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment size deltas reports to PRs
+        uses: arduino/report-size-deltas@v1
+        with:
+          # The name of the workflow artifact created by the sketch compilation workflow
+          sketches-reports-source: sketches-reports

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,0 +1,22 @@
+name: Spell Check
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+  pull_request:
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch new misspelling detections resulting from dictionary updates.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  spellcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Spell check
+        uses: codespell-project/actions-codespell@master

--- a/MDNS.cpp
+++ b/MDNS.cpp
@@ -402,7 +402,7 @@ MDNSError_t MDNS::_sendMDNSMessage(uint32_t /*peerAddress*/, uint32_t xid, int t
             ptr += slen;
          }
          
-         // PTR record (for the dns-sd service in general)
+         // PTR record (for the DNS-SD service in general)
          this->_writeDNSName((const uint8_t*)DNS_SD_SERVICE, &ptr, buf,
                                           sizeof(DNSHeader_t), 1);
          
@@ -783,9 +783,9 @@ MDNSError_t MDNS::_processMDNSQuery()
                         for (j=0; j<MDNS_MAX_SERVICES_PER_PACKET; j++) {
                            if (NULL != ptrNames[j] && ptrNamesMatches[j]) {
                               // only compare the part we have. this is incorrect, but good enough,
-                              // since actual MDNS implementations won't go here anyways, as they
+                              // since actual mDNS implementations won't go here anyways, as they
                               // should use name compression. This is just so that multiple Arduinos
-                              // running this MDNSResponder code should be able to find each other's
+                              // running this mDNSResponder code should be able to find each other's
                               // services.
                               if (ptrLensCmp[j] >= ir) 
                                  ptrNamesMatches[j] &= this->_matchStringPart(&ptrNamesCmp[j],
@@ -800,7 +800,7 @@ MDNSError_t MDNS::_processMDNSQuery()
             } while (rLen > 0 && rLen <= 128);
                         
             // if this matched a name of ours (and there are no characters left), then
-            // check wether this is an A record query (for our own name) or a PTR record query
+            // check whether this is an A record query (for our own name) or a PTR record query
             // (for one of our services).
             // if so, we'll note to send a record
             if (i < qCnt)
@@ -982,7 +982,7 @@ MDNSError_t MDNS::_processMDNSQuery()
                   for (j=0; j<MDNS_MAX_SERVICES_PER_PACKET; j++) {
                      if (servIPs[j][0] == ptrIPs[i] || servIPs[j][0] == 255) {
                         // the || part is such a hack, but it will work as long as there's only
-                        // one A record per MDNS packet. fucking DNS name compression.                     
+                        // one A record per mDNS packet. fucking DNS name compression.                     
                         ipAddr = &servIPs[j][1];
                         
                         break;
@@ -1051,7 +1051,7 @@ void MDNS::run()
    uint8_t i;
    unsigned long now = millis();
    
-   // first, look for MDNS queries to handle
+   // first, look for mDNS queries to handle
    (void)_processMDNSQuery();
    
    // are we querying a name or service? if so, should we resend the packet or time out?

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ArduinoMDNS
 
 [![Check Arduino status](https://github.com/arduino-libraries/ArduinoMDNS/actions/workflows/check-arduino.yml/badge.svg)](https://github.com/arduino-libraries/ArduinoMDNS/actions/workflows/check-arduino.yml)
+[![Compile Examples status](https://github.com/arduino-libraries/ArduinoMDNS/actions/workflows/compile-examples.yml/badge.svg)](https://github.com/arduino-libraries/ArduinoMDNS/actions/workflows/compile-examples.yml)
 [![Spell Check status](https://github.com/arduino-libraries/ArduinoMDNS/actions/workflows/spell-check.yml/badge.svg)](https://github.com/arduino-libraries/ArduinoMDNS/actions/workflows/spell-check.yml)
 
 mDNS library for Arduino. Based on [@TrippyLighting](https://github.com/TrippyLighting)'s [EthernetBonjour](https://github.com/TrippyLighting/EthernetBonjour) library.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # ArduinoMDNS
 
+[![Check Arduino status](https://github.com/arduino-libraries/ArduinoMDNS/actions/workflows/check-arduino.yml/badge.svg)](https://github.com/arduino-libraries/ArduinoMDNS/actions/workflows/check-arduino.yml)
 [![Spell Check status](https://github.com/arduino-libraries/ArduinoMDNS/actions/workflows/spell-check.yml/badge.svg)](https://github.com/arduino-libraries/ArduinoMDNS/actions/workflows/spell-check.yml)
 
 mDNS library for Arduino. Based on [@TrippyLighting](https://github.com/TrippyLighting)'s [EthernetBonjour](https://github.com/TrippyLighting/EthernetBonjour) library.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ArduinoMDNS
 
+[![Spell Check status](https://github.com/arduino-libraries/ArduinoMDNS/actions/workflows/spell-check.yml/badge.svg)](https://github.com/arduino-libraries/ArduinoMDNS/actions/workflows/spell-check.yml)
+
 mDNS library for Arduino. Based on [@TrippyLighting](https://github.com/TrippyLighting)'s [EthernetBonjour](https://github.com/TrippyLighting/EthernetBonjour) library.
 
 Supports mDNS (registering services) and DNS-SD (service discovery).

--- a/examples/Ethernet/DiscoveringServices/DiscoveringServices.ino
+++ b/examples/Ethernet/DiscoveringServices/DiscoveringServices.ino
@@ -48,7 +48,7 @@ void setup()
   
   // Initialize the mDNS library. You can now reach or ping this
   // Arduino via the host name "arduino.local", provided that your operating
-  // system is mDNS/Bonjour-enabled (such as MacOS X).
+  // system is mDNS/Bonjour-enabled (such as macOS).
   // Always call this before any other method!
   mdns.begin(Ethernet.localIP(), "arduino");
 
@@ -70,7 +70,7 @@ void loop()
   char serviceName[256];
   int length = 0;
   
-  // read in a service name from the Arduino IDE's serial monitor.
+  // read in a service name from the Arduino IDE's Serial Monitor.
   while (Serial.available()) {
     serviceName[length] = Serial.read();
     length = (length+1) % 256;
@@ -108,7 +108,7 @@ void loop()
   mdns.run();
 }
 
-// This function is called when a name is resolved via MDNS/Bonjour. We set
+// This function is called when a name is resolved via mDNS/Bonjour. We set
 // this up in the setup() function above. The name you give to this callback
 // function does not matter at all, but it must take exactly these arguments
 // as below.
@@ -159,4 +159,3 @@ void serviceFound(const char* type, MDNSServiceProtocol /*proto*/,
     }
   }
 }
-

--- a/examples/Ethernet/RegisteringServices/RegisteringServices.ino
+++ b/examples/Ethernet/RegisteringServices/RegisteringServices.ino
@@ -48,7 +48,7 @@ void setup()
 
   // Initialize the mDNS library. You can now reach or ping this
   // Arduino via the host name "arduino.local", provided that your operating
-  // system is mDNS/Bonjour-enabled (such as MacOS X).
+  // system is mDNS/Bonjour-enabled (such as macOS).
   // Always call this before any other method!
   mdns.begin(Ethernet.localIP(), "arduino");
 
@@ -56,7 +56,7 @@ void setup()
   // To do so, we call the addServiceRecord() method. The first argument is the
   // name of our service instance and its type, separated by a dot. In this
   // case, the service type is _http. There are many other service types, use
-  // google to look up some common ones, but you can also invent your own
+  // Google to look up some common ones, but you can also invent your own
   // service type, like _mycoolservice - As long as your clients know what to
   // look for, you're good to go.
   // The second argument is the port on which the service is running. This is
@@ -84,16 +84,16 @@ void loop()
   // in the browser when you connect.
   EthernetClient client = server.available();
   if (client) {
-    // an http request ends with a blank line
+    // an HTTP request ends with a blank line
     bool current_line_is_blank = true;
     while (client.connected()) {
       if (client.available()) {
         char c = client.read();
         // if we've gotten to the end of the line (received a newline
-        // character) and the line is blank, the http request has ended,
+        // character) and the line is blank, the HTTP request has ended,
         // so we can send a reply
         if (c == '\n' && current_line_is_blank) {
-          // send a standard http response header
+          // send a standard HTTP response header
           client.println("HTTP/1.1 200 OK");
           client.println("Content-Type: text/html");
           client.println();

--- a/examples/Ethernet/RegisteringServicesWithTxtRecord/RegisteringServicesWithTxtRecord.ino
+++ b/examples/Ethernet/RegisteringServicesWithTxtRecord/RegisteringServicesWithTxtRecord.ino
@@ -46,7 +46,7 @@ void setup()
 
   // Initialize the mDNS library. You can now reach or ping this
   // Arduino via the host name "arduino.local", provided that your operating
-  // system is mDNS/Bonjour-enabled (such as MacOS X).
+  // system is mDNS/Bonjour-enabled (such as macOS).
   // Always call this before any other method!
   mdns.begin(Ethernet.localIP(), "arduino");
 
@@ -54,7 +54,7 @@ void setup()
   // To do so, we call the addServiceRecord() method. The first argument is the
   // name of our service instance and its type, separated by a dot. In this
   // case, the service type is _http. There are many other service types, use
-  // google to look up some common ones, but you can also invent your own
+  // Google to look up some common ones, but you can also invent your own
   // service type, like _mycoolservice - As long as your clients know what to
   // look for, you're good to go.
   // The second argument is the port on which the service is running. This is
@@ -98,7 +98,7 @@ void loop()
   char lastLetter = '\0';
   char isPage2 = 0;
   if (client) {
-    // an http request ends with a blank line
+    // an HTTP request ends with a blank line
     bool current_line_is_blank = true;
     while (client.connected()) {
       if (client.available()) {
@@ -109,10 +109,10 @@ void loop()
         lastLetter = c;
 
         // if we've gotten to the end of the line (received a newline
-        // character) and the line is blank, the http request has ended,
+        // character) and the line is blank, the HTTP request has ended,
         // so we can send a reply
         if (c == '\n' && current_line_is_blank) {
-          // send a standard http response header
+          // send a standard HTTP response header
           client.println("HTTP/1.1 200 OK");
           client.println("Content-Type: text/html");
           client.println();

--- a/examples/Ethernet/ResolvingHostNames/ResolvingHostNames.ino
+++ b/examples/Ethernet/ResolvingHostNames/ResolvingHostNames.ino
@@ -18,7 +18,7 @@
 //  <http://www.gnu.org/licenses/>.
 //
 
-//  Illustrates how to resolve host names via MDNS (Multicast DNS)
+//  Illustrates how to resolve host names via mDNS (Multicast DNS)
 
 
 #include <SPI.h>
@@ -47,7 +47,7 @@ void setup()
   
   // Initialize the mDNS library. You can now reach or ping this
   // Arduino via the host name "arduino.local", provided that your operating
-  // system is mDNS/Bonjour-enabled (such as MacOS X).
+  // system is mDNS/Bonjour-enabled (such as macOS).
   // Always call this before any other method!
   mdns.begin(Ethernet.localIP(), "arduino");
 
@@ -67,7 +67,7 @@ void loop()
   char hostName[512];
   int length = 0;
   
-  // read in a host name from the Arduino IDE's serial monitor.
+  // read in a host name from the Arduino IDE's Serial Monitor.
   while (Serial.available()) {
     hostName[length] = Serial.read();
     length = (length+1) % 512;
@@ -118,4 +118,3 @@ void nameFound(const char* name, IPAddress ip)
     Serial.println("' timed out.");
   }
 }
-

--- a/examples/WiFi/WiFiDiscoveringServices/WiFiDiscoveringServices.ino
+++ b/examples/WiFi/WiFiDiscoveringServices/WiFiDiscoveringServices.ino
@@ -27,7 +27,7 @@
 
 char ssid[] = "yourNetwork";     //  your network SSID (name)
 char pass[] = "secretPassword";  // your network password
-int status = WL_IDLE_STATUS;     // the Wifi radio's status
+int status = WL_IDLE_STATUS;     // the WiFi radio's status
 
 WiFiUDP udp;
 MDNS mdns(udp);
@@ -51,7 +51,7 @@ void setup()
     while (true);
   }
 
-  // attempt to connect to Wifi network:
+  // attempt to connect to WiFi network:
   while ( status != WL_CONNECTED) {
     Serial.print("Attempting to connect to WPA SSID: ");
     Serial.println(ssid);
@@ -66,7 +66,7 @@ void setup()
   
   // Initialize the mDNS library. You can now reach or ping this
   // Arduino via the host name "arduino.local", provided that your operating
-  // system is mDNS/Bonjour-enabled (such as MacOS X).
+  // system is mDNS/Bonjour-enabled (such as macOS).
   // Always call this before any other method!
   mdns.begin(WiFi.localIP(), "arduino");
 
@@ -87,7 +87,7 @@ void loop()
   char serviceName[256];
   int length = 0;
   
-  // read in a service name from the Arduino IDE's serial monitor.
+  // read in a service name from the Arduino IDE's Serial Monitor.
   while (Serial.available()) {
     serviceName[length] = Serial.read();
     length = (length+1) % 256;
@@ -176,4 +176,3 @@ void serviceFound(const char* type, MDNSServiceProtocol /*proto*/,
     }
   }
 }
-

--- a/examples/WiFi/WiFiRegisteringServices/WiFiRegisteringServices.ino
+++ b/examples/WiFi/WiFiRegisteringServices/WiFiRegisteringServices.ino
@@ -27,7 +27,7 @@
 
 char ssid[] = "yourNetwork";     //  your network SSID (name)
 char pass[] = "secretPassword";  // your network password
-int status = WL_IDLE_STATUS;     // the Wifi radio's status
+int status = WL_IDLE_STATUS;     // the WiFi radio's status
 
 WiFiUDP udp;
 MDNS mdns(udp);
@@ -48,7 +48,7 @@ void setup()
     while (true);
   }
 
-  // attempt to connect to Wifi network:
+  // attempt to connect to WiFi network:
   while ( status != WL_CONNECTED) {
     Serial.print("Attempting to connect to WPA SSID: ");
     Serial.println(ssid);
@@ -65,7 +65,7 @@ void setup()
 
   // Initialize the mDNS library. You can now reach or ping this
   // Arduino via the host name "arduino.local", provided that your operating
-  // system is mDNS/Bonjour-enabled (such as MacOS X).
+  // system is mDNS/Bonjour-enabled (such as macOS).
   // Always call this before any other method!
   mdns.begin(WiFi.localIP(), "arduino");
 
@@ -73,7 +73,7 @@ void setup()
   // To do so, we call the addServiceRecord() method. The first argument is the
   // name of our service instance and its type, separated by a dot. In this
   // case, the service type is _http. There are many other service types, use
-  // google to look up some common ones, but you can also invent your own
+  // Google to look up some common ones, but you can also invent your own
   // service type, like _mycoolservice - As long as your clients know what to
   // look for, you're good to go.
   // The second argument is the port on which the service is running. This is
@@ -101,16 +101,16 @@ void loop()
   // in the browser when you connect.
   WiFiClient client = server.available();
   if (client) {
-    // an http request ends with a blank line
+    // an HTTP request ends with a blank line
     bool current_line_is_blank = true;
     while (client.connected()) {
       if (client.available()) {
         char c = client.read();
         // if we've gotten to the end of the line (received a newline
-        // character) and the line is blank, the http request has ended,
+        // character) and the line is blank, the HTTP request has ended,
         // so we can send a reply
         if (c == '\n' && current_line_is_blank) {
-          // send a standard http response header
+          // send a standard HTTP response header
           client.println("HTTP/1.1 200 OK");
           client.println("Content-Type: text/html");
           client.println();

--- a/examples/WiFi/WiFiRegisteringServicesWithTxtRecord/WiFiRegisteringServicesWithTxtRecord.ino
+++ b/examples/WiFi/WiFiRegisteringServicesWithTxtRecord/WiFiRegisteringServicesWithTxtRecord.ino
@@ -27,7 +27,7 @@
 
 char ssid[] = "yourNetwork";     //  your network SSID (name)
 char pass[] = "secretPassword";  // your network password
-int status = WL_IDLE_STATUS;     // the Wifi radio's status
+int status = WL_IDLE_STATUS;     // the WiFi radio's status
 
 WiFiUDP udp;
 MDNS mdns(udp);
@@ -48,7 +48,7 @@ void setup()
     while (true);
   }
 
-  // attempt to connect to Wifi network:
+  // attempt to connect to WiFi network:
   while ( status != WL_CONNECTED) {
     Serial.print("Attempting to connect to WPA SSID: ");
     Serial.println(ssid);
@@ -65,7 +65,7 @@ void setup()
   
   // Initialize the mDNS library. You can now reach or ping this
   // Arduino via the host name "arduino.local", provided that your operating
-  // system is mDNS/Bonjour-enabled (such as MacOS X).
+  // system is mDNS/Bonjour-enabled (such as macOS).
   // Always call this before any other method!
   mdns.begin(WiFi.localIP(), "arduino");
 
@@ -73,7 +73,7 @@ void setup()
   // To do so, we call the addServiceRecord() method. The first argument is the
   // name of our service instance and its type, separated by a dot. In this
   // case, the service type is _http. There are many other service types, use
-  // google to look up some common ones, but you can also invent your own
+  // Google to look up some common ones, but you can also invent your own
   // service type, like _mycoolservice - As long as your clients know what to
   // look for, you're good to go.
   // The second argument is the port on which the service is running. This is
@@ -117,7 +117,7 @@ void loop()
   char lastLetter = '\0';
   char isPage2 = 0;
   if (client) {
-    // an http request ends with a blank line
+    // an HTTP request ends with a blank line
     bool current_line_is_blank = true;
     while (client.connected()) {
       if (client.available()) {
@@ -128,10 +128,10 @@ void loop()
         lastLetter = c;
 
         // if we've gotten to the end of the line (received a newline
-        // character) and the line is blank, the http request has ended,
+        // character) and the line is blank, the HTTP request has ended,
         // so we can send a reply
         if (c == '\n' && current_line_is_blank) {
-          // send a standard http response header
+          // send a standard HTTP response header
           client.println("HTTP/1.1 200 OK");
           client.println("Content-Type: text/html");
           client.println();

--- a/examples/WiFi/WiFiResolvingHostNames/WiFiResolvingHostNames.ino
+++ b/examples/WiFi/WiFiResolvingHostNames/WiFiResolvingHostNames.ino
@@ -18,7 +18,7 @@
 //  <http://www.gnu.org/licenses/>.
 //
 
-//  Illustrates how to resolve host names via MDNS (Multicast DNS)
+//  Illustrates how to resolve host names via mDNS (Multicast DNS)
 
 
 #include <SPI.h>
@@ -28,7 +28,7 @@
 
 char ssid[] = "yourNetwork";     //  your network SSID (name)
 char pass[] = "secretPassword";  // your network password
-int status = WL_IDLE_STATUS;     // the Wifi radio's status
+int status = WL_IDLE_STATUS;     // the WiFi radio's status
 
 WiFiUDP udp;
 MDNS mdns(udp);
@@ -50,7 +50,7 @@ void setup()
     while (true);
   }
 
-  // attempt to connect to Wifi network:
+  // attempt to connect to WiFi network:
   while ( status != WL_CONNECTED) {
     Serial.print("Attempting to connect to WPA SSID: ");
     Serial.println(ssid);
@@ -65,7 +65,7 @@ void setup()
   
   // Initialize the mDNS library. You can now reach or ping this
   // Arduino via the host name "arduino.local", provided that your operating
-  // system is mDNS/Bonjour-enabled (such as MacOS X).
+  // system is mDNS/Bonjour-enabled (such as macOS).
   // Always call this before any other method!
   mdns.begin(WiFi.localIP(), "arduino");
 
@@ -84,7 +84,7 @@ void loop()
   char hostName[512];
   int length = 0;
   
-  // read in a host name from the Arduino IDE's serial monitor.
+  // read in a host name from the Arduino IDE's Serial Monitor.
   while (Serial.available()) {
     hostName[length] = Serial.read();
     length = (length+1) % 512;
@@ -135,4 +135,3 @@ void nameFound(const char* name, IPAddress ip)
     Serial.println("' timed out.");
   }
 }
-


### PR DESCRIPTION
This PR provides the standardized [GitHub Actions](https://github.com/features/actions)-based CI configuration for Arduino libraries.

### Dependabot

Dependabot will periodically check the versions of all actions used in the repository's workflows. If any are found to be outdated, it will submit a pull request to update them.

NOTE: Dependabot's PRs will sometimes try to pin to the patch version of the action (e.g., updating `uses: foo/bar@v1` to `uses: foo/bar@v2.3.4`). When the action author has [provided a major version ref](https://docs.github.com/en/actions/creating-actions/about-actions#using-release-management-for-actions), use that instead (e.g., `uses: foo/bar@v2`). Once the major version has been updated in the workflow, Dependabot should not submit an update PR again until the next major version bump. So even if the PRs from Dependabot are not always exactly correct, their value lies in bringing the maintainer's attention to the fact that the action version in use is outdated. Dependabot will automatically close its PR once the workflow has been updated.

More information:
https://docs.github.com/en/github/administering-a-repository/keeping-your-actions-up-to-date-with-dependabot

### Spell check

On every push, pull request, and periodically, use [the `codespell-project/actions-codespell` action](https://github.com/codespell-project/actions-codespell) to check for commonly misspelled words.

In the event of a false positive, the problematic word should be added, in all lowercase, to the `ignore-words-list` field of `./.codespellrc`. Regardless of the case of the word in the false positive, it must be in all lowercase in the ignore list. The ignore list is comma-separated with no spaces.

### Arduino Lint

On every push, pull request, and periodically, run [Arduino Lint](https://github.com/arduino/arduino-lint) to check for common problems not related to the project code.

### Compile examples

On every push or pull request that affects library source or example files, and periodically, use [the `arduino/compile-sketches` action](https://github.com/arduino/compile-sketches) to compile all example sketches for the specified boards.

### Report size deltas

On creation or commit to a pull request, use [the `arduino/report-size-deltas` action](https://github.com/arduino/report-size-deltas) to comment a report of the resulting change in memory usage of the examples to the PR thread.

---
Fixes https://github.com/arduino-libraries/ArduinoMDNS/issues/10