### PR TITLE
Fix invalid call to free() in 'addServiceRecord'

### DIFF
--- a/MDNS.cpp
+++ b/MDNS.cpp
@@ -1154,7 +1154,7 @@ int MDNS::addServiceRecord(const char* name, uint16_t port,
          if (NULL == this->_serviceRecords[i]) {
             record = (MDNSServiceRecord_t*)my_malloc(sizeof(MDNSServiceRecord_t));
             if (NULL != record) {
-               record->name = record->textContent = NULL;
+               record->name = record->textContent = record->servName = NULL;
                
                record->name = (uint8_t*)my_malloc(strlen((char*)name));
                if (NULL == record->name)


### PR DESCRIPTION
If some memory allocation in the member function addServiceRecord fails it will call 'goto errorReturn;'.
At errorReturn there is a call to my_free which ALWAYS frees 'record->servName' at the moment.

This PR sets servName to 0, which will later prevent the call to free.

Live-Screenshot of the bug:
![image](https://github.com/arduino-libraries/ArduinoMDNS/assets/116807061/1015a4b3-2928-4e48-8e61-398f3202ef60)
assert failed: heap_caps_free heap_caps.c:360 (heap != NULL && "free() target pointer is outside heap areas"