### PR TITLE
Update Arduino Lint configuration following Library Manager submission

### DIFF
--- a/.github/workflows/check-arduino.yml
+++ b/.github/workflows/check-arduino.yml
@@ -22,8 +22,7 @@ jobs:
         uses: arduino/arduino-lint-action@v1
         with:
           compliance: specification
-          # Change this to "update" once the library is added to the index.
-          library-manager: submit
+          library-manager: update
           # Always use this setting for official repositories. Remove for 3rd party projects.
           official: true
           project-type: library


### PR DESCRIPTION
The "Check Arduino" workflow uses Arduino Lint (via the arduino/arduino-lint-action) to check for problems with the library.

Different rules are appropriate for libraries that are being prepared for submission to Arduino Library Manager when compared to after submission, when the rules must instead check for problems related to publishing new releases of an already registered library. For this reason, the action has a `library-manager` input for configuring which phase the library is in.

The library was recently registered in Arduino Library Manager, which caused the "Check Arduino" workflow runs to start failing due to still using the "submit" action configuration. The problem is resolved by updating the workflow to use the "update" action configuration.