### PR TITLE
Added missing includes IPAddress.h and Udp.h

### DIFF
--- a/MDNS.h
+++ b/MDNS.h
@@ -26,6 +26,8 @@ extern "C" {
 }
 
 #include <Arduino.h>
+#include <IPAddress.h>
+#include <Udp.h>
 
 typedef uint8_t byte;
 


### PR DESCRIPTION
So as to allow for any order when using MDNS.h, it should include any headers it requires. It needs symbols from both IPAddress.h and Udp.h. IPAddress.h is included by Udp.h, but including it explicitly adds a bit of clarity to someone reading the code.