### PR TITLE
Remove CI build for Portenta H7 / M4 core

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -76,11 +76,6 @@ jobs:
               - name: arduino:samd
             type: ethernet
             artifact-name-suffix: arduino-samd-nano_33_iot
-          - fqbn: arduino:mbed_portenta:envie_m7:target_core=cm4
-            platforms: |
-              - name: arduino:mbed_portenta
-            type: ethernet
-            artifact-name-suffix: arduino-mbed_portenta-envie_m7-cm4
           - fqbn: arduino:mbed_portenta:envie_m7
             platforms: |
               - name: arduino:mbed_portenta


### PR DESCRIPTION
The reason behind this is that the M4 core can not access memory area that's relevant for the Ethernet driver. Put simply, Ethernet does not work from the Portenta H7 / M4 core.